### PR TITLE
add sha-256 checksums to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 This Repository contains the initial genesis state for a number of different
 sui networks:
 
-- devnet
-- testnet
-- mainnet
+- devnet (SHA-256: `1442200406a8ae89189060bfcf88fbb29c637d72cb10819b9878eba608d786de`)
+- testnet (SHA-256: `df78eb5e525294d29c9f710a0d80c3b8e5c9f6e2e6485098584f0695d80de2aa`)
+- mainnet (SHA-256: `b57abe29e52ea89b68df6d08224c234f6e2cb1fa357203b12ba50dd4776f9038`)


### PR DESCRIPTION
This PR adds the SHA-256 checksum of all genesis blobs to the README.
I think it makes sense to be able to check the hash value before downloading the blob. However, it would require updating these values whenever there is a new genesis blob (especially for devnet).

Closes #31 